### PR TITLE
feat: add infrastructure persistence and outbox scaffolding

### DIFF
--- a/src/AstraID.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/AstraID.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,0 +1,50 @@
+using AstraID.Domain.Abstractions;
+using AstraID.Domain.Repositories;
+using AstraID.Infrastructure.Messaging;
+using AstraID.Infrastructure.Messaging.Background;
+using AstraID.Infrastructure.Persistence;
+using AstraID.Infrastructure.Persistence.Interceptors;
+using AstraID.Infrastructure.Persistence.Repositories;
+using AstraID.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AstraID.Infrastructure.DependencyInjection;
+
+/// <summary>
+/// DI helpers for Infrastructure layer.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddPersistence(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddScoped<DomainEventsCollectorInterceptor>();
+        services.AddDbContext<AstraIdDbContext>((sp, opt) =>
+        {
+            var interceptor = sp.GetRequiredService<DomainEventsCollectorInterceptor>();
+            var conn = configuration["ASTRAID_DB_CONN"];
+            opt.UseSqlServer(conn);
+            opt.AddInterceptors(interceptor);
+        });
+
+        services.AddScoped<IUnitOfWork, EfUnitOfWork>();
+        services.AddScoped<IAppUserRepository, AppUserRepository>();
+        services.AddScoped<IRoleRepository, RoleRepository>();
+        services.AddScoped<IClientRepository, ClientRepository>();
+        services.AddScoped<IPermissionRepository, PermissionRepository>();
+        services.AddScoped<IUserSessionRepository, UserSessionRepository>();
+        services.AddScoped<IUserConsentRepository, UserConsentRepository>();
+        services.AddScoped<IAuditEventRepository, AuditEventRepository>();
+        services.AddScoped<IPasswordHistoryRepository, PasswordHistoryRepository>();
+        return services;
+    }
+
+    public static IServiceCollection AddOutbox(this IServiceCollection services)
+    {
+        services.AddScoped<IOutboxPublisher, OutboxPublisher>();
+        services.AddSingleton<IDomainEventDispatcher, DomainEventDispatcher>();
+        services.AddHostedService<OutboxHostedService>();
+        return services;
+    }
+}

--- a/src/AstraID.Infrastructure/Messaging/Background/OutboxHostedService.cs
+++ b/src/AstraID.Infrastructure/Messaging/Background/OutboxHostedService.cs
@@ -1,0 +1,42 @@
+using AstraID.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace AstraID.Infrastructure.Messaging.Background;
+
+/// <summary>
+/// Background service that publishes messages from the outbox.
+/// </summary>
+public class OutboxHostedService : BackgroundService
+{
+    private readonly IServiceProvider _provider;
+    private readonly TimeSpan _interval = TimeSpan.FromSeconds(30);
+
+    public OutboxHostedService(IServiceProvider provider) => _provider = provider;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            using var scope = _provider.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<AstraIdDbContext>();
+
+            var messages = await db.OutboxMessages
+                .Where(m => m.ProcessedUtc == null)
+                .OrderBy(m => m.CreatedUtc)
+                .Take(20)
+                .ToListAsync(stoppingToken);
+
+            foreach (var message in messages)
+            {
+                // For now, simply mark as processed
+                message.ProcessedUtc = DateTime.UtcNow;
+                // No deserialization to domain event types here, kept simple
+            }
+
+            await db.SaveChangesAsync(stoppingToken);
+            await Task.Delay(_interval, stoppingToken);
+        }
+    }
+}

--- a/src/AstraID.Infrastructure/Messaging/DomainEventDispatcher.cs
+++ b/src/AstraID.Infrastructure/Messaging/DomainEventDispatcher.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using AstraID.Domain.Abstractions;
+using AstraID.Domain.Primitives;
+
+namespace AstraID.Infrastructure.Messaging;
+
+/// <summary>
+/// Simple domain event dispatcher that resolves handlers from DI and invokes them.
+/// </summary>
+public class DomainEventDispatcher : IDomainEventDispatcher
+{
+    private readonly IServiceProvider _provider;
+
+    public DomainEventDispatcher(IServiceProvider provider) => _provider = provider;
+
+    public async Task DispatchAsync(IEnumerable<IDomainEvent> events, CancellationToken ct = default)
+    {
+        // Resolve handlers of type IDomainEventHandler<T> if present
+        foreach (var domainEvent in events)
+        {
+            var handlerType = typeof(IDomainEventHandler<>).MakeGenericType(domainEvent.GetType());
+            var handlers = (IEnumerable<object>)(_provider.GetService(typeof(IEnumerable<>).MakeGenericType(handlerType)) ?? Array.Empty<object>());
+            foreach (var handler in handlers)
+            {
+                var method = handlerType.GetMethod("HandleAsync");
+                if (method != null)
+                    await (Task)method.Invoke(handler, new object?[] { domainEvent, ct })!;
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Handler contract for domain events.
+/// </summary>
+public interface IDomainEventHandler<in TEvent> where TEvent : IDomainEvent
+{
+    Task HandleAsync(TEvent domainEvent, CancellationToken ct = default);
+}

--- a/src/AstraID.Infrastructure/Messaging/OutboxDbConfig.cs
+++ b/src/AstraID.Infrastructure/Messaging/OutboxDbConfig.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace AstraID.Infrastructure.Messaging;
+
+/// <summary>
+/// EF Core configuration for <see cref="OutboxMessage"/>.
+/// </summary>
+public class OutboxDbConfig : IEntityTypeConfiguration<OutboxMessage>
+{
+    public void Configure(EntityTypeBuilder<OutboxMessage> builder)
+    {
+        builder.ToTable("OutboxMessages");
+        builder.HasKey(o => o.Id);
+        builder.Property(o => o.Type).IsRequired().HasMaxLength(512);
+        builder.Property(o => o.PayloadJson).IsRequired();
+        builder.Property(o => o.CreatedUtc).IsRequired();
+    }
+}

--- a/src/AstraID.Infrastructure/Messaging/OutboxMessage.cs
+++ b/src/AstraID.Infrastructure/Messaging/OutboxMessage.cs
@@ -1,0 +1,16 @@
+using AstraID.Domain.Abstractions;
+
+namespace AstraID.Infrastructure.Messaging;
+
+/// <summary>
+/// Outbox message stored for later processing.
+/// </summary>
+public class OutboxMessage : IOutboxMessage
+{
+    public Guid Id { get; set; }
+    public DateTime CreatedUtc { get; set; }
+    public string Type { get; set; } = string.Empty;
+    public string PayloadJson { get; set; } = string.Empty;
+    public string? CorrelationId { get; set; }
+    public DateTime? ProcessedUtc { get; set; }
+}

--- a/src/AstraID.Infrastructure/Messaging/OutboxPublisher.cs
+++ b/src/AstraID.Infrastructure/Messaging/OutboxPublisher.cs
@@ -1,0 +1,20 @@
+using AstraID.Domain.Abstractions;
+using AstraID.Persistence;
+
+namespace AstraID.Infrastructure.Messaging;
+
+/// <summary>
+/// Persists outbox messages in the database.
+/// </summary>
+public class OutboxPublisher : IOutboxPublisher
+{
+    private readonly AstraIdDbContext _db;
+
+    public OutboxPublisher(AstraIdDbContext db) => _db = db;
+
+    public Task EnqueueAsync(IOutboxMessage message, CancellationToken ct = default)
+    {
+        _db.OutboxMessages.Add((OutboxMessage)message);
+        return Task.CompletedTask;
+    }
+}

--- a/src/AstraID.Infrastructure/OpenIddict/ClientApplicationBridge.cs
+++ b/src/AstraID.Infrastructure/OpenIddict/ClientApplicationBridge.cs
@@ -1,0 +1,40 @@
+using AstraID.Domain.Entities;
+using OpenIddict.Abstractions;
+
+namespace AstraID.Infrastructure.OpenIddict;
+
+/// <summary>
+/// Bridges client aggregate changes to OpenIddict applications.
+/// </summary>
+public class ClientApplicationBridge
+{
+    private readonly IOpenIddictApplicationManager _apps;
+
+    public ClientApplicationBridge(IOpenIddictApplicationManager apps) => _apps = apps;
+
+    public async Task EnsureCreatedAsync(Client client, CancellationToken ct = default)
+    {
+        var descriptor = new OpenIddictApplicationDescriptor
+        {
+            ClientId = client.ClientId,
+            DisplayName = client.DisplayName,
+            Type = client.Type
+        };
+        await _apps.CreateAsync(descriptor, ct);
+    }
+
+    public async Task ApplyChangesAsync(Client client, CancellationToken ct = default)
+    {
+        var app = await _apps.FindByClientIdAsync(client.ClientId, ct);
+        if (app == null)
+        {
+            await EnsureCreatedAsync(client, ct);
+            return;
+        }
+        var descriptor = new OpenIddictApplicationDescriptor();
+        await _apps.PopulateAsync(descriptor, app, ct);
+        descriptor.DisplayName = client.DisplayName;
+        descriptor.Type = client.Type;
+        await _apps.UpdateAsync(app, descriptor, ct);
+    }
+}

--- a/src/AstraID.Infrastructure/Persistence/EfUnitOfWork.cs
+++ b/src/AstraID.Infrastructure/Persistence/EfUnitOfWork.cs
@@ -1,0 +1,17 @@
+using AstraID.Domain.Abstractions;
+using AstraID.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace AstraID.Infrastructure.Persistence;
+
+/// <summary>
+/// Unit of Work implementation over <see cref="AstraIdDbContext"/>.
+/// </summary>
+public class EfUnitOfWork : IUnitOfWork
+{
+    private readonly AstraIdDbContext _db;
+
+    public EfUnitOfWork(AstraIdDbContext db) => _db = db;
+
+    public Task<int> SaveChangesAsync(CancellationToken ct = default) => _db.SaveChangesAsync(ct);
+}

--- a/src/AstraID.Infrastructure/Persistence/Interceptors/DomainEventsCollectorInterceptor.cs
+++ b/src/AstraID.Infrastructure/Persistence/Interceptors/DomainEventsCollectorInterceptor.cs
@@ -1,0 +1,46 @@
+using System.Text.Json;
+using System.Linq;
+using AstraID.Domain.Primitives;
+using AstraID.Infrastructure.Messaging;
+using AstraID.Persistence;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore;
+
+namespace AstraID.Infrastructure.Persistence.Interceptors;
+
+/// <summary>
+/// Collects domain events from aggregates and stores them as outbox messages.
+/// </summary>
+public sealed class DomainEventsCollectorInterceptor : SaveChangesInterceptor
+{
+    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+        DbContextEventData eventData,
+        InterceptionResult<int> result,
+        CancellationToken cancellationToken = default)
+    {
+        if (eventData.Context is not AstraIdDbContext db)
+            return base.SavingChangesAsync(eventData, result, cancellationToken);
+
+        var aggregates = db.ChangeTracker.Entries<AggregateRoot<Guid>>()
+            .Where(e => e.Entity.DomainEvents.Any())
+            .ToList();
+
+        foreach (var entry in aggregates)
+        {
+            foreach (var domainEvent in entry.Entity.DomainEvents)
+            {
+                var message = new OutboxMessage
+                {
+                    Id = Guid.NewGuid(),
+                    Type = domainEvent.GetType().FullName ?? string.Empty,
+                    PayloadJson = JsonSerializer.Serialize(domainEvent, domainEvent.GetType()),
+                    CreatedUtc = DateTime.UtcNow
+                };
+                db.OutboxMessages.Add(message);
+            }
+            entry.Entity.ClearDomainEvents();
+        }
+
+        return base.SavingChangesAsync(eventData, result, cancellationToken);
+    }
+}

--- a/src/AstraID.Infrastructure/Persistence/Repositories/AppUserRepository.cs
+++ b/src/AstraID.Infrastructure/Persistence/Repositories/AppUserRepository.cs
@@ -1,0 +1,28 @@
+using AstraID.Domain.Entities;
+using AstraID.Domain.Repositories;
+using AstraID.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace AstraID.Infrastructure.Persistence.Repositories;
+
+/// <summary>
+/// EF Core implementation of <see cref="IAppUserRepository"/>.
+/// </summary>
+public class AppUserRepository : IAppUserRepository
+{
+    private readonly AstraIdDbContext _db;
+
+    public AppUserRepository(AstraIdDbContext db) => _db = db;
+
+    public Task<AppUser?> GetByIdAsync(Guid id, CancellationToken ct = default) =>
+        _db.Users.FindAsync(new object?[] { id }, ct).AsTask();
+
+    public Task<AppUser?> GetByEmailAsync(string normalizedEmail, CancellationToken ct = default) =>
+        _db.Users.FirstOrDefaultAsync(u => u.NormalizedEmail == normalizedEmail, ct);
+
+    public Task<bool> ExistsByEmailAsync(string normalizedEmail, CancellationToken ct = default) =>
+        _db.Users.AnyAsync(u => u.NormalizedEmail == normalizedEmail, ct);
+
+    public Task AddAsync(AppUser user, CancellationToken ct = default) =>
+        _db.Users.AddAsync(user, ct).AsTask();
+}

--- a/src/AstraID.Infrastructure/Persistence/Repositories/AuditEventRepository.cs
+++ b/src/AstraID.Infrastructure/Persistence/Repositories/AuditEventRepository.cs
@@ -1,0 +1,18 @@
+using AstraID.Domain.Entities;
+using AstraID.Domain.Repositories;
+using AstraID.Persistence;
+
+namespace AstraID.Infrastructure.Persistence.Repositories;
+
+/// <summary>
+/// EF Core implementation of <see cref="IAuditEventRepository"/>.
+/// </summary>
+public class AuditEventRepository : IAuditEventRepository
+{
+    private readonly AstraIdDbContext _db;
+
+    public AuditEventRepository(AstraIdDbContext db) => _db = db;
+
+    public Task AddAsync(AuditEvent auditEvent, CancellationToken ct = default) =>
+        _db.AuditEvents.AddAsync(auditEvent, ct).AsTask();
+}

--- a/src/AstraID.Infrastructure/Persistence/Repositories/ClientRepository.cs
+++ b/src/AstraID.Infrastructure/Persistence/Repositories/ClientRepository.cs
@@ -1,0 +1,22 @@
+using AstraID.Domain.Entities;
+using AstraID.Domain.Repositories;
+using AstraID.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace AstraID.Infrastructure.Persistence.Repositories;
+
+/// <summary>
+/// EF Core implementation of <see cref="IClientRepository"/>.
+/// </summary>
+public class ClientRepository : IClientRepository
+{
+    private readonly AstraIdDbContext _db;
+
+    public ClientRepository(AstraIdDbContext db) => _db = db;
+
+    public Task<Client?> GetByClientIdAsync(string clientId, Guid? tenantId, CancellationToken ct = default) =>
+        _db.Clients.FirstOrDefaultAsync(c => c.ClientId == clientId && c.TenantId == tenantId, ct);
+
+    public Task AddAsync(Client client, CancellationToken ct = default) =>
+        _db.Clients.AddAsync(client, ct).AsTask();
+}

--- a/src/AstraID.Infrastructure/Persistence/Repositories/PasswordHistoryRepository.cs
+++ b/src/AstraID.Infrastructure/Persistence/Repositories/PasswordHistoryRepository.cs
@@ -1,0 +1,27 @@
+using AstraID.Domain.Entities;
+using AstraID.Domain.Repositories;
+using AstraID.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace AstraID.Infrastructure.Persistence.Repositories;
+
+/// <summary>
+/// EF Core implementation of <see cref="IPasswordHistoryRepository"/>.
+/// </summary>
+public class PasswordHistoryRepository : IPasswordHistoryRepository
+{
+    private readonly AstraIdDbContext _db;
+
+    public PasswordHistoryRepository(AstraIdDbContext db) => _db = db;
+
+    public async Task<IReadOnlyList<string>> GetRecentHashesAsync(Guid userId, int take, CancellationToken ct = default) =>
+        await _db.PasswordHistory
+            .Where(p => p.UserId == userId)
+            .OrderByDescending(p => p.CreatedUtc)
+            .Select(p => p.PasswordHash)
+            .Take(take)
+            .ToListAsync(ct);
+
+    public Task AddAsync(PasswordHistory history, CancellationToken ct = default) =>
+        _db.PasswordHistory.AddAsync(history, ct).AsTask();
+}

--- a/src/AstraID.Infrastructure/Persistence/Repositories/PermissionRepository.cs
+++ b/src/AstraID.Infrastructure/Persistence/Repositories/PermissionRepository.cs
@@ -1,0 +1,22 @@
+using AstraID.Domain.Entities;
+using AstraID.Domain.Repositories;
+using AstraID.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace AstraID.Infrastructure.Persistence.Repositories;
+
+/// <summary>
+/// EF Core implementation of <see cref="IPermissionRepository"/>.
+/// </summary>
+public class PermissionRepository : IPermissionRepository
+{
+    private readonly AstraIdDbContext _db;
+
+    public PermissionRepository(AstraIdDbContext db) => _db = db;
+
+    public Task<Permission?> GetByIdAsync(Guid id, CancellationToken ct = default) =>
+        _db.Permissions.FindAsync(new object?[] { id }, ct).AsTask();
+
+    public Task AddAsync(Permission permission, CancellationToken ct = default) =>
+        _db.Permissions.AddAsync(permission, ct).AsTask();
+}

--- a/src/AstraID.Infrastructure/Persistence/Repositories/RoleRepository.cs
+++ b/src/AstraID.Infrastructure/Persistence/Repositories/RoleRepository.cs
@@ -1,0 +1,25 @@
+using AstraID.Domain.Entities;
+using AstraID.Domain.Repositories;
+using AstraID.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace AstraID.Infrastructure.Persistence.Repositories;
+
+/// <summary>
+/// EF Core implementation of <see cref="IRoleRepository"/>.
+/// </summary>
+public class RoleRepository : IRoleRepository
+{
+    private readonly AstraIdDbContext _db;
+
+    public RoleRepository(AstraIdDbContext db) => _db = db;
+
+    public Task<AppRole?> GetByIdAsync(Guid id, CancellationToken ct = default) =>
+        _db.Roles.FindAsync(new object?[] { id }, ct).AsTask();
+
+    public Task<AppRole?> GetByNameAsync(string normalizedName, CancellationToken ct = default) =>
+        _db.Roles.FirstOrDefaultAsync(r => r.NormalizedName == normalizedName, ct);
+
+    public Task AddAsync(AppRole role, CancellationToken ct = default) =>
+        _db.Roles.AddAsync(role, ct).AsTask();
+}

--- a/src/AstraID.Infrastructure/Persistence/Repositories/UserConsentRepository.cs
+++ b/src/AstraID.Infrastructure/Persistence/Repositories/UserConsentRepository.cs
@@ -1,0 +1,22 @@
+using AstraID.Domain.Entities;
+using AstraID.Domain.Repositories;
+using AstraID.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace AstraID.Infrastructure.Persistence.Repositories;
+
+/// <summary>
+/// EF Core implementation of <see cref="IUserConsentRepository"/>.
+/// </summary>
+public class UserConsentRepository : IUserConsentRepository
+{
+    private readonly AstraIdDbContext _db;
+
+    public UserConsentRepository(AstraIdDbContext db) => _db = db;
+
+    public Task<UserConsent?> GetByUserAndClientAsync(Guid userId, string clientId, CancellationToken ct = default) =>
+        _db.UserConsents.FirstOrDefaultAsync(c => c.UserId == userId && c.ClientId == clientId, ct);
+
+    public Task AddAsync(UserConsent consent, CancellationToken ct = default) =>
+        _db.UserConsents.AddAsync(consent, ct).AsTask();
+}

--- a/src/AstraID.Infrastructure/Persistence/Repositories/UserSessionRepository.cs
+++ b/src/AstraID.Infrastructure/Persistence/Repositories/UserSessionRepository.cs
@@ -1,0 +1,27 @@
+using AstraID.Domain.Entities;
+using AstraID.Domain.Repositories;
+using AstraID.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace AstraID.Infrastructure.Persistence.Repositories;
+
+/// <summary>
+/// EF Core implementation of <see cref="IUserSessionRepository"/>.
+/// </summary>
+public class UserSessionRepository : IUserSessionRepository
+{
+    private readonly AstraIdDbContext _db;
+
+    public UserSessionRepository(AstraIdDbContext db) => _db = db;
+
+    public Task<UserSession?> GetActiveByDeviceAsync(Guid userId, string deviceId, CancellationToken ct = default) =>
+        _db.UserSessions.FirstOrDefaultAsync(s => s.UserId == userId && s.DeviceId == deviceId && s.RevokedUtc == null, ct);
+
+    public Task AddAsync(UserSession session, CancellationToken ct = default) =>
+        _db.UserSessions.AddAsync(session, ct).AsTask();
+
+    public Task<int> RevokeAllAsync(Guid userId, string reason, DateTime utcNow, CancellationToken ct = default) =>
+        _db.UserSessions.Where(s => s.UserId == userId && s.RevokedUtc == null)
+            .ExecuteUpdateAsync(up => up.SetProperty(s => s.RevokedUtc, utcNow)
+                                        .SetProperty(s => s.RevocationReason, reason), ct);
+}

--- a/src/AstraID.Persistence/AstraID.Persistence.csproj
+++ b/src/AstraID.Persistence/AstraID.Persistence.csproj
@@ -6,6 +6,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\AstraID.Infrastructure\Messaging\OutboxMessage.cs" Link="Messaging/OutboxMessage.cs" />
+    <Compile Include="..\AstraID.Infrastructure\Messaging\OutboxDbConfig.cs" Link="Messaging/OutboxDbConfig.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="9.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />

--- a/src/AstraID.Persistence/AstraIdDbContext.cs
+++ b/src/AstraID.Persistence/AstraIdDbContext.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using DataProtectionKeyEntity = Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.DataProtectionKey;
+using AstraID.Infrastructure.Messaging;
 
 namespace AstraID.Persistence;
 
@@ -24,6 +25,7 @@ public class AstraIdDbContext : IdentityDbContext<AppUser, AppRole, Guid>, IData
     public DbSet<AuditEvent> AuditEvents => Set<AuditEvent>();
     public DbSet<DataProtectionKeyEntity> DataProtectionKeys => Set<DataProtectionKeyEntity>();
     public DbSet<Tenant> Tenants => Set<Tenant>();
+    public DbSet<OutboxMessage> OutboxMessages => Set<OutboxMessage>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {


### PR DESCRIPTION
## Summary
- add EF Core repositories and unit of work
- collect domain events into outbox for later processing
- register persistence and outbox services in DI

## Testing
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689df2ce61f48326baff29dfbe4f50a7